### PR TITLE
Adding a couple of gems that make middleman work properly on windows

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,7 @@ gem 'fittext'
 gem 'middleman-blog'
 gem 'middleman-google-analytics'
 gem 'slim'
+# Needed for timezone data files to be installed
+gem 'tzinfo-data'
+# Needed to avoid polling on windows when running development server
+gem 'wdm', '>= 0.1.0' if Gem.win_platform?

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,7 +35,6 @@ GEM
     erubis (2.7.0)
     execjs (2.6.0)
     ffi (1.9.10)
-    ffi (1.9.10-x64-mingw32)
     fittext (0.0.5)
       compass (>= 0.10.0.rc3)
     haml (4.0.7)
@@ -90,8 +89,6 @@ GEM
     multi_json (1.11.2)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
-    nokogiri (1.6.6.2-x64-mingw32)
-      mini_portile (~> 0.6.0)
     padrino-helpers (0.12.5)
       i18n (~> 0.6, >= 0.6.7)
       padrino-support (= 0.12.5)
@@ -124,8 +121,6 @@ GEM
     tilt (1.4.1)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    tzinfo-data (1.2015.7)
-      tzinfo (>= 1.0.0)
     uber (0.0.15)
     uglifier (2.7.2)
       execjs (>= 0.3.0)
@@ -135,7 +130,6 @@ GEM
 
 PLATFORMS
   ruby
-  x64-mingw32
 
 DEPENDENCIES
   activesupport
@@ -145,7 +139,6 @@ DEPENDENCIES
   middleman-blog
   middleman-google-analytics
   slim
-  tzinfo-data
 
 BUNDLED WITH
-   1.11.2
+   1.10.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,6 +35,7 @@ GEM
     erubis (2.7.0)
     execjs (2.6.0)
     ffi (1.9.10)
+    ffi (1.9.10-x64-mingw32)
     fittext (0.0.5)
       compass (>= 0.10.0.rc3)
     haml (4.0.7)
@@ -89,6 +90,8 @@ GEM
     multi_json (1.11.2)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
+    nokogiri (1.6.6.2-x64-mingw32)
+      mini_portile (~> 0.6.0)
     padrino-helpers (0.12.5)
       i18n (~> 0.6, >= 0.6.7)
       padrino-support (= 0.12.5)
@@ -121,6 +124,8 @@ GEM
     tilt (1.4.1)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    tzinfo-data (1.2015.7)
+      tzinfo (>= 1.0.0)
     uber (0.0.15)
     uglifier (2.7.2)
       execjs (>= 0.3.0)
@@ -130,6 +135,7 @@ GEM
 
 PLATFORMS
   ruby
+  x64-mingw32
 
 DEPENDENCIES
   activesupport
@@ -139,6 +145,7 @@ DEPENDENCIES
   middleman-blog
   middleman-google-analytics
   slim
+  tzinfo-data
 
 BUNDLED WITH
-   1.10.6
+   1.11.2


### PR DESCRIPTION
tzdata-info is needed if that data isn't bundled with your os.
wdm is needed on windows only to avoid polling for file changes.